### PR TITLE
Add additional validation for SIN length

### DIFF
--- a/social-insurance-number.js
+++ b/social-insurance-number.js
@@ -45,6 +45,10 @@
   };
 
   SocialInsuranceNumber.prototype.isValid = function() {
+    if(this.normalizedValue().length > SIN_LENGTH) {
+      return false;
+    }
+
     return luhnChecksum(this.normalizedValue()) % 10 === 0;
   };
 

--- a/test/social_insurance_number.test.js
+++ b/test/social_insurance_number.test.js
@@ -95,6 +95,11 @@ describe('SocialInsuranceNumber', function() {
         expect(new SocialInsuranceNumber(input).isValid()).toEqual(true);
       });
     });
+
+    it("returns false for a SIN that is too long", function() {
+      const invalidSin =  "1306925445";
+      expect(new SocialInsuranceNumber(invalidSin).isValid()).toEqual(false);
+    });
   });
 
   describe("#isTemporary", function() {


### PR DESCRIPTION
I noticed that this library had a bug where the SIN length wasn't validated properly. 

The reproduction steps are as follows:

```
let validSin = "547 082 784";
let sin = new SocialInsuranceNumber(validSin);

sin.isValid(); // returns true

let inValidSin = `${validSin}123`;
let sin = new SocialInsuranceNumber(invalidSin);

sin.isValid(); // returns true
```

I've added validation to check the length of the SIN. The check occurs before the Luhn's algorithm validation is run, but after the value is normalized from the user. 