### PR TITLE
fix(es5): make es-check pass

### DIFF
--- a/social-insurance-number.js
+++ b/social-insurance-number.js
@@ -88,15 +88,17 @@
     if (doesNotStartWith) {
       // convert a single entry to a list
       doesNotStartWith = [].concat(doesNotStartWith);
-      var possibleSinPrefixes = [...new Set([].concat.apply([], Object.values(PROVINCES)))];
+      var possibleSinPrefixes = Array.from(new Set([].concat.apply([], Object.values(PROVINCES))));
 
       if (province) {
         possibleSinPrefixes = PROVINCES[province];
       }
 
-      var validStartsWithChoices = possibleSinPrefixes.filter(
-        (prefix) => !doesNotStartWith.includes(String(prefix))
-      );
+      var filter = function(prefix) {
+        return !doesNotStartWith.includes(String(prefix))
+      }
+
+      var validStartsWithChoices = possibleSinPrefixes.filter(filter);
 
       if (!validStartsWithChoices.length) {
         throw "Cannot find a valid number to start with.";


### PR DESCRIPTION
This lib doesn't have a transpile step and we should enforce that our source be es5 until it does.

Fixes the failing check added in #29 