### PR TITLE
ci: install dependencies in publish step

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -48,6 +48,21 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: yarn install
+
       - name: Run semantic-release
         run: yarn run semantic-release
         env:


### PR DESCRIPTION
Package step [is failing](https://github.com/wealthsimple/social-insurance-number/runs/4369356453?check_suite_focus=true#step:3:7) with `command not found`, let's install dependencies first.