### PR TITLE
change owners from co-clients to co-cd [skip ci]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @wealthsimple/co-clients
+* @wealthsimple/co-cd


### PR DESCRIPTION
changing ownership from `co-clients` as per this doc https://wealthsimple.quip.com/48fWAN6hQ8sD/GitHub-CODEOWNERS 