### PR TITLE
FEF-390 Add archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # social-insurance-number [![Default](https://github.com/wealthsimple/social-insurance-number/actions/workflows/default.yml/badge.svg)](https://github.com/wealthsimple/social-insurance-number/actions/workflows/default.yml) [![Code Climate](https://codeclimate.com/github/wealthsimple/social-insurance-number/badges/gpa.svg)](https://codeclimate.com/github/wealthsimple/social-insurance-number)
 
+## Notice
+This repo is now **archived**. The library has been moved into  [client-core](https://github.com/wealthsimple/client-core/tree/master/packages/social-insurance-number). 
+
+If you are using the public version of this package that is published on the yarn registry, please switch over to using the private version of this package that is published on Nexus. You can do this using: 
+`yarn remove social-insurance-number && yarn add @wealthsimple/social-insurance-number`.
+
+---
+
 `social-insurance-number` is a Canadian SIN (Social Insurance Number) parser and generator for the browser and Node.js.
 
 ## Parsing


### PR DESCRIPTION
We want to archive this repo since it has been ported into [client-core](https://github.com/wealthsimple/client-core/tree/master/packages/social-insurance-number) for private publishing. 

This PR adds a notice describing that ^ and explains how devs can switch over to the @wealthsimple version of the package instead.

